### PR TITLE
簡単なプロフィールの表示

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,3 +280,6 @@ DEPENDENCIES
   uglifier (= 2.5.3)
   web-console (= 2.0.0.beta3)
   will_paginate (= 3.0.7)
+
+BUNDLED WITH
+   1.11.0

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -228,7 +228,7 @@ input {
 #session_remember_me {
   width: auto;
   margin-left: 0;
-}_
+}
 
 /* Users index */
 .users {
@@ -286,4 +286,11 @@ span.picture {
   input {
     border: 0;
   }
+}
+
+.self_introduction {
+  border-style: dotted;
+  border-width: 3px;
+  padding: 10px 5px 10px 20px;
+  border-radius: 10px;
 }

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -228,7 +228,7 @@ input {
 #session_remember_me {
   width: auto;
   margin-left: 0;
-}
+}_
 
 /* Users index */
 .users {

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,20 +3,20 @@ class UsersController < ApplicationController
                                         :following, :followers]
   before_action :correct_user,   only: [:edit, :update]
   before_action :admin_user,     only: :destroy
-  
+
   def index
     @users = User.paginate(page: params[:page])
   end
-  
+
   def show
     @user = User.find(params[:id])
     @microposts = @user.microposts.paginate(page: params[:page])
   end
-  
+
   def new
     @user = User.new
   end
-  
+
   def create
     @user = User.new(user_params)
     if @user.save
@@ -27,10 +27,10 @@ class UsersController < ApplicationController
       render 'new'
     end
   end
-  
+
   def edit
   end
-  
+
   def update
     if @user.update_attributes(user_params)
       flash[:success] = "Profile updated"
@@ -39,42 +39,42 @@ class UsersController < ApplicationController
       render 'edit'
     end
   end
-  
+
   def destroy
     User.find(params[:id]).destroy
     flash[:success] = "User deleted"
     redirect_to users_url
   end
-  
+
   def following
     @title = "Following"
     @user  = User.find(params[:id])
     @users = @user.following.paginate(page: params[:page])
     render 'show_follow'
   end
-  
+
   def followers
     @title = "Followers"
     @user  = User.find(params[:id])
     @users = @user.followers.paginate(page: params[:page])
     render 'show_follow'
   end
-  
+
   private
-    
+
     def user_params
       params.require(:user).permit(:name, :email, :password,
-                                   :password_confirmation)
+                                   :password_confirmation, :self_introduction)
     end
-    
+
     # Before filters
-    
+
     # Confirms the correct user.
     def correct_user
       @user = User.find(params[:id])
       redirect_to(root_url) unless current_user?(@user)
     end
-    
+
     # Confirms an admin user.
     def admin_user
       redirect_to(root_url) unless current_user.admin?

--- a/app/views/shared/_self_introduction.html.erb
+++ b/app/views/shared/_self_introduction.html.erb
@@ -1,0 +1,1 @@
+<%= current_user.self_introduction %>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -12,4 +12,7 @@
     </strong>
     followers
   </a>
+  <a>
+    
+  </a>
 </div>

--- a/app/views/shared/_stats.html.erb
+++ b/app/views/shared/_stats.html.erb
@@ -12,7 +12,4 @@
     </strong>
     followers
   </a>
-  <a>
-    
-  </a>
 </div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -5,22 +5,26 @@
   <div class="col-md-6 col-md-offset-3">
     <%= form_for(@user) do |f| %>
       <%= render 'shared/error_messages', object: f.object %>
-    
+
       <%= f.label :name %>
       <%= f.text_field :name, class: 'form-control' %>
-      
+
       <%= f.label :email %>
       <%= f.email_field :email, class: 'form-control' %>
-      
+
       <%= f.label :password %>
       <%= f.password_field :password, class: 'form-control' %>
-      
+
       <%= f.label :password_confirmation, "Confirmation" %>
       <%= f.password_field :password_confirmation, class: 'form-control' %>
-      
+
+      <%= f.label :self_introduction %>
+      <%= f.text_area :self_introduction, class: 'form-control' %>
+
       <%= f.submit "Save changes", class: "btn btn-primary" %>
+
     <% end %>
-    
+
     <div class="gravatar_edit">
       <%= gravatar_for @user %>
       <a href="http://gravatar.com/emails" target=_blank>change</a>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= will_paginate %>
 
-<ul class="users">
+<ul class="users microposts">
   <%= render @users %>
 </ul>
 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,9 @@
     <section class="stats">
       <%= render 'shared/stats' %>
     </section>
+    <section class="self_introduction">
+      <%= render 'shared/self_introduction' %>
+    </section>
   </aside>
   <div class="col-md-8">
     <%= render 'follow_form' if logged_in? %>

--- a/db/migrate/20160418032841_add_self_introduction_to_users.rb
+++ b/db/migrate/20160418032841_add_self_introduction_to_users.rb
@@ -1,0 +1,5 @@
+class AddSelfIntroductionToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :self_introduction, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141111214811) do
+ActiveRecord::Schema.define(version: 20160418032841) do
 
   create_table "microposts", force: :cascade do |t|
     t.text     "content"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20141111214811) do
     t.datetime "activated_at"
     t.string   "reset_digest"
     t.datetime "reset_sent_at"
+    t.text     "self_introduction"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true


### PR DESCRIPTION
## 関連URL
*なし

## 概要
*この変更によってユーザープロフィールの自己紹介文が表示されるようになる．

## 技術的変更点概要
*migrationによって，usersテーブルにself_introductionカラムを追加
*editページでself_introductionカラムを変更フォームを追加
*users_controllerでself_introductionカラムをデータベースに保存できるように機能追加
*ユーザープロフィールページで表示させた
*validationで文字制限をつけた

## UI・デザインに対する変更
*ユーザー紹介の表示を線で囲み強調させた

## テスト結果とテスト項目
*なし

## 今回保留した項目とTODOリスト
*テスト

## その他
*なし